### PR TITLE
Feature: Tree shaking (modular version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,19 @@
     },
     "main": "dist/node/index.js",
     "types": "dist/node/index.d.ts",
+    "typesVersions": {
+      "*": {
+        "translate": ["dist/node/translate/index.d.ts"],
+        "schemas/MOSMETRO": ["dist/node/schemas/mosmetro.d.ts"],
+        "schemas/YANDEX_MONEY": ["dist/node/schemas/yandex_money.d.ts"]
+      }
+    },
+    "exports": {
+        "./translate": "./dist/node/translate/index.js",
+        "./schemas/MOSMETRO": "./dist/node/schemas/mosmetro.js",
+        "./schemas/YANDEX_MONEY": "./dist/node/schemas/yandex_money.js",
+        "./package.json": "./package.json"
+    },
     "files": [
         "dist/**/*"
     ],

--- a/src/schemas/mosmetro.ts
+++ b/src/schemas/mosmetro.ts
@@ -1,0 +1,3 @@
+import { Schema } from "../schema";
+import mosmetro from "../generated/mosmetro";
+export const MOSMETRO = Schema.load(mosmetro);

--- a/src/schemas/yandex_money.ts
+++ b/src/schemas/yandex_money.ts
@@ -1,0 +1,3 @@
+import { Schema } from "../schema";
+import yandex_money from "../generated/yandex_money";
+export const YANDEX_MONEY = Schema.load(yandex_money);

--- a/src/translate/index.ts
+++ b/src/translate/index.ts
@@ -1,0 +1,1 @@
+export { translate } from "../engine";

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es6",
         "module": "es2015",
         "moduleResolution": "node",
         "lib": ["es2015", "es2016", "es2017", "es2020", "dom"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
-        "target": "es5",
-        "module": "commonjs",
+        "target": "es6",
+        "module": "es6",
+        "moduleResolution": "node",
         "lib": ["es2015", "es2016", "es2017", "es2020", "dom"],
         "downlevelIteration": true,
         "declaration": true,


### PR DESCRIPTION
As descripbed on https://github.com/nalgeon/iuliia-js/issues/2

Now it's possible:
>import {translate} from "iuliia/translate";
>import {MOSMETRO} from "iuliia/schemas/MOSMETRO";
>translate("Юлия Щеглова", MOSMETRO);

Bundle size reduce from 70K to 4K

Traditional use of Lib also works fine.

Currently for MOSMETRO and YANDEX_MONEY schemas.
