### PR TITLE
fix: temporarily rollback tree-shaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ Transliteration means representing Cyrillic data (mainly names and geographic lo
 `Iuliia` makes transliteration as easy as:
 
 ```ts
+// Typescript, ES6
 import * as iuliia from "iuliia";
 iuliia.translate("Юлия Щеглова", iuliia.WIKIPEDIA);
 'Yuliya Shcheglova'
 ```
 
 ```js
+// CommonJS
 const iuliia = require("iuliia");
 iuliia.translate("Юлия Щеглова", iuliia.WIKIPEDIA);
 'Yuliya Shcheglova'
@@ -31,7 +33,7 @@ iuliia.translate("Юлия Щеглова", iuliia.WIKIPEDIA);
 -   Correctly implements not only the base mapping, but all the special rules for letter combinations and word endings.
 -   Simple API and zero third-party dependencies.
 
-For schema details and other information, see <https://dangry.ru/iuliia> (in Russian).
+For schema details and other information, see <https://iuliia.ru/> (in Russian).
 
 [Issues and limitations](https://github.com/nalgeon/iuliia/blob/master/README.md#issues-and-limitations)
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,15 @@ Transliteration means representing Cyrillic data (mainly names and geographic lo
 
 `Iuliia` makes transliteration as easy as:
 
+```ts
+import * as iuliia from "iuliia";
+iuliia.translate("Юлия Щеглова", iuliia.WIKIPEDIA);
+'Yuliya Shcheglova'
+```
+
 ```js
-> import iuliia from "iuliia";
-> iuliia.translate("Юлия Щеглова", iuliia.WIKIPEDIA);
+const iuliia = require("iuliia");
+iuliia.translate("Юлия Щеглова", iuliia.WIKIPEDIA);
 'Yuliya Shcheglova'
 ```
 

--- a/package.json
+++ b/package.json
@@ -37,25 +37,6 @@
     },
     "main": "dist/node/index.js",
     "types": "dist/node/index.d.ts",
-    "typesVersions": {
-        "*": {
-            "translate": [
-                "dist/node/translate/index.d.ts"
-            ],
-            "schemas/MOSMETRO": [
-                "dist/node/schemas/mosmetro.d.ts"
-            ],
-            "schemas/YANDEX_MONEY": [
-                "dist/node/schemas/yandex_money.d.ts"
-            ]
-        }
-    },
-    "exports": {
-        "./translate": "./dist/node/translate/index.js",
-        "./schemas/MOSMETRO": "./dist/node/schemas/mosmetro.js",
-        "./schemas/YANDEX_MONEY": "./dist/node/schemas/yandex_money.js",
-        "./package.json": "./package.json"
-    },
     "files": [
         "dist/**/*"
     ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,35 +2,32 @@ import { translate } from "./engine";
 import { Schema } from "./schema";
 import { Schemas } from "./schemas";
 
-export = {
-    translate,
-    Schema,
-    Schemas,
-    ALA_LC: Schemas.get("ala_lc"),
-    ALA_LC_ALT: Schemas.get("ala_lc_alt"),
-    BGN_PCGN: Schemas.get("bgn_pcgn"),
-    BGN_PCGN_ALT: Schemas.get("bgn_pcgn_alt"),
-    BS_2979: Schemas.get("bs_2979"),
-    BS_2979_ALT: Schemas.get("bs_2979_alt"),
-    GOST_16876: Schemas.get("gost_16876"),
-    GOST_16876_ALT: Schemas.get("gost_16876_alt"),
-    GOST_52290: Schemas.get("gost_52290"),
-    GOST_52535: Schemas.get("gost_52535"),
-    GOST_7034: Schemas.get("gost_7034"),
-    GOST_779: Schemas.get("gost_779"),
-    GOST_779_ALT: Schemas.get("gost_779_alt"),
-    ICAO_DOC_9303: Schemas.get("icao_doc_9303"),
-    ISO_9_1954: Schemas.get("iso_9_1954"),
-    ISO_9_1968: Schemas.get("iso_9_1968"),
-    ISO_9_1968_ALT: Schemas.get("iso_9_1968_alt"),
-    MOSMETRO: Schemas.get("mosmetro"),
-    MVD_310: Schemas.get("mvd_310"),
-    MVD_310_FR: Schemas.get("mvd_310_fr"),
-    MVD_782: Schemas.get("mvd_782"),
-    SCIENTIFIC: Schemas.get("scientific"),
-    TELEGRAM: Schemas.get("telegram"),
-    UNGEGN_1987: Schemas.get("ungegn_1987"),
-    WIKIPEDIA: Schemas.get("wikipedia"),
-    YANDEX_MAPS: Schemas.get("yandex_maps"),
-    YANDEX_MONEY: Schemas.get("yandex_money"),
-};
+export { translate, Schema, Schemas };
+
+export const ALA_LC = Schemas.get("ala_lc");
+export const ALA_LC_ALT = Schemas.get("ala_lc_alt");
+export const BGN_PCGN = Schemas.get("bgn_pcgn");
+export const BGN_PCGN_ALT = Schemas.get("bgn_pcgn_alt");
+export const BS_2979 = Schemas.get("bs_2979");
+export const BS_2979_ALT = Schemas.get("bs_2979_alt");
+export const GOST_16876 = Schemas.get("gost_16876");
+export const GOST_16876_ALT = Schemas.get("gost_16876_alt");
+export const GOST_52290 = Schemas.get("gost_52290");
+export const GOST_52535 = Schemas.get("gost_52535");
+export const GOST_7034 = Schemas.get("gost_7034");
+export const GOST_779 = Schemas.get("gost_779");
+export const GOST_779_ALT = Schemas.get("gost_779_alt");
+export const ICAO_DOC_9303 = Schemas.get("icao_doc_9303");
+export const ISO_9_1954 = Schemas.get("iso_9_1954");
+export const ISO_9_1968 = Schemas.get("iso_9_1968");
+export const ISO_9_1968_ALT = Schemas.get("iso_9_1968_alt");
+export const MOSMETRO = Schemas.get("mosmetro");
+export const MVD_310 = Schemas.get("mvd_310");
+export const MVD_310_FR = Schemas.get("mvd_310_fr");
+export const MVD_782 = Schemas.get("mvd_782");
+export const SCIENTIFIC = Schemas.get("scientific");
+export const TELEGRAM = Schemas.get("telegram");
+export const UNGEGN_1987 = Schemas.get("ungegn_1987");
+export const WIKIPEDIA = Schemas.get("wikipedia");
+export const YANDEX_MAPS = Schemas.get("yandex_maps");
+export const YANDEX_MONEY = Schemas.get("yandex_money");

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { translate } from "./engine";
 import { Schema } from "./schema";
 import { Schemas } from "./schemas";
 
-export default {
+export = {
     translate,
     Schema,
     Schemas,

--- a/src/schemas/mosmetro.ts
+++ b/src/schemas/mosmetro.ts
@@ -1,3 +1,0 @@
-import { Schema } from "../schema";
-import mosmetro from "../generated/mosmetro";
-export const MOSMETRO = Schema.load(mosmetro);

--- a/src/schemas/yandex_money.ts
+++ b/src/schemas/yandex_money.ts
@@ -1,3 +1,0 @@
-import { Schema } from "../schema";
-import yandex_money from "../generated/yandex_money";
-export const YANDEX_MONEY = Schema.load(yandex_money);

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -1,7 +1,7 @@
-import iuliia from "../src/index";
+import { Schemas, translate, WIKIPEDIA } from "../src/index";
 
 test("schema names", () => {
-    const names = iuliia.Schemas.names();
+    const names = Schemas.names();
     expect(names).toEqual([
         "ala_lc",
         "ala_lc_alt",
@@ -34,32 +34,31 @@ test("schema names", () => {
 });
 
 test("get schema by name", () => {
-    const schema = iuliia.Schemas.get("wikipedia");
-    expect(schema).toEqual(iuliia.WIKIPEDIA);
+    const schema = Schemas.get("wikipedia");
+    expect(schema).toEqual(WIKIPEDIA);
 });
 
 test("schema not found", () => {
     expect(() => {
-        iuliia.Schemas.get("whatever");
+        Schemas.get("whatever");
     }).toThrowError("No such schema: whatever");
 });
 
 test("translate", () => {
-    const schema = iuliia.Schemas.get("wikipedia");
-    const translated = iuliia.translate("Юлия", schema);
+    const schema = Schemas.get("wikipedia");
+    const translated = translate("Юлия", schema);
     expect(translated).toBe("Yuliya");
 });
 
 test("translate", () => {
-    const schema = iuliia.Schemas.get("wikipedia");
-    const translated = iuliia.translate("Привет, (привет), человечество!", schema);
+    const schema = Schemas.get("wikipedia");
+    const translated = translate("Привет, (привет), человечество!", schema);
     expect(translated).toBe("Privet, (privet), chelovechestvo!");
 });
 
-
 function samples(): Array<[string, number, string, string]> {
     const samples: Array<[string, number, string, string]> = [];
-    for (const schema of iuliia.Schemas.values()) {
+    for (const schema of Schemas.values()) {
         let idx = 1;
         for (const sample of schema.samples) {
             const source = sample[0];
@@ -71,6 +70,6 @@ function samples(): Array<[string, number, string, string]> {
 }
 
 test.each(samples())("%s %d: %s", (name, idx, source, expected) => {
-    const schema = iuliia.Schemas.get(name);
-    expect(iuliia.translate(source, schema)).toBe(expected);
+    const schema = Schemas.get(name);
+    expect(translate(source, schema)).toBe(expected);
 });

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
-        "target": "es6",
-        "module": "es2015",
+        "target": "es5",
+        "module": "CommonJS",
         "moduleResolution": "node",
         "lib": ["es2015", "es2016", "es2017", "es2020", "dom"],
         "removeComments": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
-        "target": "es6",
-        "module": "es6",
+        "target": "es5",
+        "module": "CommonJS",
         "moduleResolution": "node",
         "lib": ["es2015", "es2016", "es2017", "es2020", "dom"],
         "downlevelIteration": true,


### PR DESCRIPTION
### Fixed
 - #22 

Now the correct and working way to import iuliia are the following:

CommonJS namespace import:

```ts
const iuliia = require('iuliia');
```

CommonJS named import:

```ts
const {translate, WIKIPEDIA} = require('iuliia');
```

ES6 / TS namespace import:

```ts
import * as iuliia from 'iuliia';
```

ES6 / TS named import:

```ts
import {translate, WIKIPEDIA} from 'iuliia';
```
